### PR TITLE
Erro ao utilizar método por XML-RPC

### DIFF
--- a/l10n_br_base_address/models/zip_search.py
+++ b/l10n_br_base_address/models/zip_search.py
@@ -28,7 +28,12 @@ class ZipSearchMixin(models.AbstractModel):
         city = self.env['res.city'].search([
             ('name', '=ilike', res['cidade']),
             ('state_id', '=', state.id)])
-
+        
+        if(res['end'] == None):
+            res['end'] = False
+        if(res['bairro'] == None):
+            res['bairro'] = False
+        
         return {
             'zip': zip_code,
             'street': res['end'],


### PR DESCRIPTION
O protocolo de XML-RPC do odoo, não aceita respostas com o valor None.
Quando se procura uma cidade de CEP único, os valores end e bairro do objeto res, vinham com este valor.
Este ajuste altera o valor de None para False (aceito pelo XML-RPC) corrigindo o erro